### PR TITLE
When `EOF` (`C-d`) is received, quit interactive prompt

### DIFF
--- a/src/client/Main.cpp
+++ b/src/client/Main.cpp
@@ -397,6 +397,11 @@ SessionSelectionResult selectSession(const std::string& ClientID,
 
     std::cout << "\nChoose 1-" << QuitChoice << ": ";
     std::cin >> UserChoice;
+    if (std::cin.eof())
+    {
+      UserChoice = QuitChoice;
+      break;
+    }
     std::cin.clear();
     std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
     if (UserChoice == 0 || UserChoice > QuitChoice)


### PR DESCRIPTION
`std::cin.clear()` does clear the eofbit, but to get `stdin` back to working state we also need to call `clearerr`, but I've made changes to just quit interactive mode when EOF is received.

(fixes #15)