### PR TITLE
Fixed compile errors when building from source on fedora linux.

### DIFF
--- a/include/core/monomux/Log.hpp
+++ b/include/core/monomux/Log.hpp
@@ -18,6 +18,7 @@
  */
 #pragma once
 #include <cassert>
+#include <cstdint>
 #include <memory>
 #include <sstream>
 #include <string_view>

--- a/src/server/Server.cpp
+++ b/src/server/Server.cpp
@@ -16,10 +16,12 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <algorithm>
 #include <chrono>
 #include <iomanip>
 #include <set>
 #include <thread>
+
 
 #include "monomux/adt/POD.hpp"
 #include "monomux/control/PascalString.hpp"


### PR DESCRIPTION
Description
  When building the project from source using g++ (GCC) 14.2.1 you get the following errors
  Log.hpp:68:16: error: ‘int8_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
  68 | constexpr std::int8_t MaximumVerbosity = log::Min - log::Default;

  Log.hpp:68:16: error: ‘int8_t’ in namespace ‘std’ does not name a type; did you mean ‘wint_t’?
  68 | constexpr std::int8_t MaximumVerbosity = log::Min - log::Default;
  This pr fixes this issues



Key Changes
  Added the relevant header include declarations to fix the compile error in 


